### PR TITLE
Fix support for differing sysfs naming conventions

### DIFF
--- a/batterymon
+++ b/batterymon
@@ -197,16 +197,21 @@ class Battery:
         # "(energy|charge)_full_design"
 
         # naming convention 1: charge_full, charge_now, current_now
-        if os.path.exists(os.path.join(self.__dirname, 'charge_full')):
-            energy_full = int_or_zero(cat(self.__dirname, 'charge_full'))
-            energy_now = int_or_zero(cat(self.__dirname, 'charge_now'))
-            power_now = int_or_zero(cat(self.__dirname, 'current_now'))
-
         # naming convention 2: energy_full, energy_now, power_now
-        elif os.path.exists(os.path.join(self.__dirname, 'energy_full')):
-            energy_full = int_or_zero(cat(self.__dirname, 'energy_full'))
-            energy_now = int_or_zero(cat(self.__dirname, 'energy_now'))
-            power_now = int_or_zero(cat(self.__dirname, 'power_now'))
+        energy_full = int_or_zero( \
+                cat(self.__dirname, 'charge_full') or \
+                cat(self.__dirname, 'energy_full') \
+        )
+
+        energy_now = int_or_zero( \
+                cat(self.__dirname, 'charge_now') or \
+                cat(self.__dirname, 'energy_now') \
+        )
+
+        power_now = int_or_zero( \
+                cat(self.__dirname, 'current_now') or \
+                cat(self.__dirname, 'power_now') \
+        )
 
         if energy_full > 0:
             charge_level = 100 * energy_now // energy_full


### PR DESCRIPTION
This fixes an issue where the battery constantly reads at 0%.

It's because (at least on my system) the naming conventions for the
special files inside the sysfs tree are different from what the script
expects.

The script expects:
- /sys/class/power_supply/BAT*/energy_full
- /sys/class/power_supply/BAT*/energy_now
- /sys/class/power_supply/BAT*/power_now

My sysfs has:
- /sys/class/power_supply/BAT*/charge_full
- /sys/class/power_supply/BAT*/charge_now
- /sys/class/power_supply/BAT*/current_now

Unfortunately I am unable to find the exact commit log where this naming
convention changed, but now the script will support both and everyone
will be happy.

This bug was also observed in kernel 2.6.38.7.
## Evidence

$ uname -a

Linux delicious 3.2.2 #1 SMP Fri Jan 27 15:19:49 CST 2012 x86_64 Intel(R) Atom(TM) CPU N455   @ 1.66GHz GenuineIntel GNU/Linux

$ ls -la /sys/class/power_supply/BAT1/

```
total 0
drwxr-xr-x 3 root root    0 Feb  8 15:20 .
drwxr-xr-x 3 root root    0 Feb  8 15:20 ..
-rw-r--r-- 1 root root 4096 Feb 13 10:44 alarm
-r--r--r-- 1 root root 4096 Feb  8 15:20 charge_full
-r--r--r-- 1 root root 4096 Feb 13 10:44 charge_full_design
-r--r--r-- 1 root root 4096 Feb  8 15:20 charge_now
-r--r--r-- 1 root root 4096 Feb  8 15:20 current_now
-r--r--r-- 1 root root 4096 Feb 13 10:44 cycle_count
lrwxrwxrwx 1 root root    0 Feb 13 10:44 device -> ../../../PNP0C0A:00
-r--r--r-- 1 root root 4096 Feb 13 10:44 manufacturer
-r--r--r-- 1 root root 4096 Feb 13 10:44 model_name
drwxr-xr-x 2 root root    0 Feb 13 10:44 power
-r--r--r-- 1 root root 4096 Feb  8 15:20 present
-r--r--r-- 1 root root 4096 Feb 13 10:44 serial_number
-r--r--r-- 1 root root 4096 Feb  8 15:20 status
lrwxrwxrwx 1 root root    0 Feb  8 16:01 subsystem -> ../../../../../../class/power_supply
-r--r--r-- 1 root root 4096 Feb 13 10:44 technology
-r--r--r-- 1 root root 4096 Feb 13 10:33 type
-rw-r--r-- 1 root root 4096 Feb  8 16:01 uevent
-r--r--r-- 1 root root 4096 Feb 13 10:44 voltage_min_design
-r--r--r-- 1 root root 4096 Feb  8 15:20 voltage_now
```
